### PR TITLE
WA-405 Improve error message, use gometalinter from HEAD

### DIFF
--- a/.gometalinter
+++ b/.gometalinter
@@ -1,5 +1,5 @@
 {
-  "Enable": ["vet", "vetshadow", "gotype", "deadcode", "gocyclo", "golint", "varcheck", "structcheck", "aligncheck", "errcheck", "ineffassign", "interfacer", "unconvert", "goconst", "gas", "goimports", "misspell"],
+  "Enable": ["vet", "vetshadow", "gotype", "deadcode", "gocyclo", "golint", "varcheck", "structcheck", "maligned", "errcheck", "ineffassign", "interfacer", "unconvert", "goconst", "gas", "goimports", "misspell"],
   "Deadline": "5m",
   "Vendor": true,
   "Concurrency": 4

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,8 @@ go:
   - tip
 
 install:
-  - go get -u gopkg.in/alecthomas/gometalinter.v1
-  - gometalinter.v1 --install
+  - go get -u github.com/alecthomas/gometalinter
+  - gometalinter --install
 
 script:
   - make install

--- a/Makefile
+++ b/Makefile
@@ -5,14 +5,14 @@ build: fmt
 fmt:
 	@go fmt ./...
 
-lint:
+lint: install
 	@gometalinter.v1 ./... --config=.gometalinter
 
 test:
 	@go list ./... | xargs go test
 
 install:
-	@go install
+	@go install ./...
 
 cov:
 	@go test -test.covermode=count -test.coverprofile coverage.cov

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ fmt:
 	@go fmt ./...
 
 lint: install
-	@gometalinter.v1 ./... --config=.gometalinter
+	@gometalinter ./... --config=.gometalinter
 
 test:
 	@go list ./... | xargs go test
@@ -20,4 +20,4 @@ cov:
 
 tools:
 	@echo "govendor" && go get -u github.com/kardianos/govendor
-	@echo "gometalinter.v1" && go get -u gopkg.in/alecthomas/gometalinter.v1
+	@echo "gometalinter" && go get -u github.com/alecthomas/gometalinter

--- a/driver/postgres/driver.go
+++ b/driver/postgres/driver.go
@@ -131,11 +131,11 @@ func (db *postgres) ApplyMigrations(ctx context.Context, files []file.File, up b
 
 	for _, file := range files {
 		if _, err := tx.ExecContext(ctx, file.SQL); err != nil {
-			return rollback(errors.Annotate(err, "executing migration failed"))
+			return rollback(errors.Annotatef(err, "executing %s migration failed", file.Base))
 		}
 
 		if _, err := tx.ExecContext(ctx, applyMigrationSQL[up], file.Version); err != nil {
-			return rollback(errors.Annotate(err, "executing migration failed"))
+			return rollback(errors.Annotatef(err, "executing %s migration failed", file.Base))
 		}
 	}
 


### PR DESCRIPTION
We'll use gometalinter from HEAD, because of this issue:
https://github.com/golang/go/issues/21712

It won't lint external packages, that cause some problems on Travis.