### PR TITLE
Add verbose logging

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -28,6 +28,7 @@ func New() *cli.App {
 			Action:    cmd.Create,
 			Flags: []cli.Flag{
 				flag.Flags[flag.Path],
+				flag.Flags[flag.Verbose],
 			},
 		},
 		{
@@ -39,6 +40,8 @@ func New() *cli.App {
 				flag.Flags[flag.Path],
 				flag.Flags[flag.URL],
 				flag.Flags[flag.Timeout],
+				flag.Flags[flag.TimeoutDuration],
+				flag.Flags[flag.Verbose],
 			},
 		},
 		{
@@ -50,6 +53,8 @@ func New() *cli.App {
 				flag.Flags[flag.Path],
 				flag.Flags[flag.URL],
 				flag.Flags[flag.Timeout],
+				flag.Flags[flag.TimeoutDuration],
+				flag.Flags[flag.Verbose],
 			},
 		},
 	}
@@ -58,7 +63,9 @@ func New() *cli.App {
 		flag.Flags[flag.Path],
 		flag.Flags[flag.URL],
 		flag.Flags[flag.Timeout],
+		flag.Flags[flag.TimeoutDuration],
 		flag.Flags[flag.NoVerify],
+		flag.Flags[flag.Verbose],
 	}
 
 	return app

--- a/commander/commander.go
+++ b/commander/commander.go
@@ -4,10 +4,9 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/wallester/migrate/direction"
-
 	"github.com/juju/errors"
 	"github.com/urfave/cli"
+	"github.com/wallester/migrate/direction"
 	"github.com/wallester/migrate/flag"
 	"github.com/wallester/migrate/migrator"
 )

--- a/commander/commander.go
+++ b/commander/commander.go
@@ -100,25 +100,22 @@ func parseMigrateArguments(c *cli.Context) (*migrator.Args, error) {
 		return nil, flag.NewRequiredFlagError(flag.URL)
 	}
 
-	timeoutSeconds := 1
+	timeoutDuration := time.Second
 	if s := flag.Get(c, flag.Timeout); s != "" {
-		var err error
-		timeoutSeconds, err = strconv.Atoi(s)
+		timeoutSeconds, err := strconv.Atoi(s)
 		if err != nil {
 			return nil, flag.NewWrongFormatFlagError(flag.Timeout)
 		}
+
+		timeoutDuration = time.Duration(timeoutSeconds) * time.Second
 	}
 
-	timeoutDuration := time.Second
 	if s := flag.Get(c, flag.TimeoutDuration); s != "" {
 		var err error
 		timeoutDuration, err = time.ParseDuration(s)
 		if err != nil {
 			return nil, flag.NewWrongFormatFlagError(flag.TimeoutDuration)
 		}
-
-		// Set timeoutSecond to 0 if timeout duration is specified.
-		timeoutSeconds = 0
 	}
 
 	dbConnectionTimeoutDuration := time.Second
@@ -146,7 +143,6 @@ func parseMigrateArguments(c *cli.Context) (*migrator.Args, error) {
 	return &migrator.Args{
 		Path:                        path,
 		URL:                         url,
-		TimeoutSeconds:              timeoutSeconds,
 		Steps:                       steps,
 		NoVerify:                    noVerify,
 		TimeoutDuration:             timeoutDuration,

--- a/commander/commander_test.go
+++ b/commander/commander_test.go
@@ -118,15 +118,23 @@ func (suite *CommanderTestSuite) Test_Up_ReturnsError_InCaseOfMigratorError() {
 	// Arrange
 	suite.flagSet.String("path", "", "")
 	suite.flagSet.String("url", "", "")
-	suite.flagSet.String("timeout", "", "")
-	suite.Require().NoError(suite.flagSet.Parse([]string{"--path", "testdata", "--url", "connectionurl", "--timeout", "10"}))
+	suite.flagSet.String("timeout-duration", "", "")
+	suite.flagSet.Duration("db-conn-timeout-duration", 10*time.Second, "")
+	suite.Require().NoError(
+		suite.flagSet.Parse([]string{
+			"--path", "testdata",
+			"--url", "connectionurl",
+			"--db-conn-timeout-duration", "10s",
+			"--timeout-duration", "10s",
+		}),
+	)
 
 	args := migrator.Args{
-		Path:            "testdata",
-		URL:             "connectionurl",
-		Direction:       direction.Up,
-		Steps:           0,
-		TimeoutDuration: 10 * time.Second,
+		Path:                        "testdata",
+		URL:                         "connectionurl",
+		Direction:                   direction.Up,
+		TimeoutDuration:             10 * time.Second,
+		DBConnectionTimeoutDuration: 10 * time.Second,
 	}
 
 	suite.migratorMock.On("Migrate", args).Return(suite.expectedErr).Once()
@@ -151,18 +159,61 @@ func (suite *CommanderTestSuite) Test_Up_ReturnsError_InCaseOfInvalidArgument() 
 	suite.EqualError(errors.Cause(err), "parsing <n> failed")
 }
 
-func (suite *CommanderTestSuite) Test_Up_ReturnsNil_InCaseOfSuccess() {
+func (suite *CommanderTestSuite) Test_Up_ReturnsNil_InCaseOfSuccessAndTimeoutDuration() {
 	// Arrange
 	suite.flagSet.String("path", "", "")
 	suite.flagSet.String("url", "", "")
-	suite.Require().NoError(suite.flagSet.Parse([]string{"--path", "testdata", "--url", "connectionurl"}))
+	suite.flagSet.String("timeout-duration", "", "")
+	suite.flagSet.Duration("db-conn-timeout-duration", 10*time.Second, "")
+	suite.Require().NoError(
+		suite.flagSet.Parse([]string{
+			"--path", "testdata",
+			"--url", "connectionurl",
+			"--db-conn-timeout-duration", "10s",
+			"--timeout-duration", "10s",
+		}),
+	)
 
 	args := migrator.Args{
-		Path:            "testdata",
-		URL:             "connectionurl",
-		Direction:       direction.Up,
-		Steps:           0,
-		TimeoutDuration: 10 * time.Second,
+		Path:                        "testdata",
+		URL:                         "connectionurl",
+		Direction:                   direction.Up,
+		Steps:                       0,
+		TimeoutDuration:             10 * time.Second,
+		DBConnectionTimeoutDuration: 10 * time.Second,
+	}
+
+	suite.migratorMock.On("Migrate", args).Return(nil).Once()
+
+	// Act
+	err := suite.commander.Up(suite.ctx)
+
+	// Assert
+	suite.NoError(err)
+}
+
+func (suite *CommanderTestSuite) Test_Up_ReturnsNil_InCaseOfSuccessAndTimeout() {
+	// Arrange
+	suite.flagSet.String("path", "", "")
+	suite.flagSet.String("url", "", "")
+	suite.flagSet.String("timeout", "", "")
+	suite.flagSet.Duration("db-conn-timeout-duration", 10*time.Second, "")
+	suite.Require().NoError(
+		suite.flagSet.Parse([]string{
+			"--path", "testdata",
+			"--url", "connectionurl",
+			"--db-conn-timeout-duration", "10s",
+			"--timeout", "10",
+		}),
+	)
+
+	args := migrator.Args{
+		Path:                        "testdata",
+		URL:                         "connectionurl",
+		Direction:                   direction.Up,
+		Steps:                       0,
+		TimeoutDuration:             10 * time.Second,
+		DBConnectionTimeoutDuration: 10 * time.Second,
 	}
 
 	suite.migratorMock.On("Migrate", args).Return(nil).Once()
@@ -178,14 +229,25 @@ func (suite *CommanderTestSuite) Test_Up_ReturnsNil_InCaseOfArgumentN() {
 	// Arrange
 	suite.flagSet.String("path", "", "")
 	suite.flagSet.String("url", "", "")
-	suite.Require().NoError(suite.flagSet.Parse([]string{"--path", "testdata", "--url", "connectionurl", "10"}))
+	suite.flagSet.String("timeout-duration", "", "")
+	suite.flagSet.Duration("db-conn-timeout-duration", 10*time.Second, "")
+	suite.Require().NoError(
+		suite.flagSet.Parse([]string{
+			"--path", "testdata",
+			"--url", "connectionurl",
+			"--db-conn-timeout-duration", "10s",
+			"--timeout-duration", "10s",
+			"10",
+		}),
+	)
 
 	args := migrator.Args{
-		Path:            "testdata",
-		URL:             "connectionurl",
-		Direction:       direction.Up,
-		Steps:           10,
-		TimeoutDuration: 10 * time.Second,
+		Path:                        "testdata",
+		URL:                         "connectionurl",
+		Direction:                   direction.Up,
+		Steps:                       10,
+		TimeoutDuration:             10 * time.Second,
+		DBConnectionTimeoutDuration: 10 * time.Second,
 	}
 
 	suite.migratorMock.On("Migrate", args).Return(nil).Once()
@@ -221,14 +283,25 @@ func (suite *CommanderTestSuite) Test_Down_ReturnsError_InCaseOfMigratorError() 
 	// Arrange
 	suite.flagSet.String("path", "", "")
 	suite.flagSet.String("url", "", "")
-	suite.Require().NoError(suite.flagSet.Parse([]string{"--path", "testdata", "--url", "connectionurl", "123"}))
+	suite.flagSet.String("timeout-duration", "", "")
+	suite.flagSet.Duration("db-conn-timeout-duration", 10*time.Second, "")
+	suite.Require().NoError(
+		suite.flagSet.Parse([]string{
+			"--path", "testdata",
+			"--url", "connectionurl",
+			"--db-conn-timeout-duration", "10s",
+			"--timeout-duration", "10s",
+			"123",
+		}),
+	)
 
 	args := migrator.Args{
-		Path:            "testdata",
-		URL:             "connectionurl",
-		Direction:       direction.Down,
-		Steps:           123,
-		TimeoutDuration: 10 * time.Second,
+		Path:                        "testdata",
+		URL:                         "connectionurl",
+		Direction:                   direction.Down,
+		Steps:                       123,
+		TimeoutDuration:             10 * time.Second,
+		DBConnectionTimeoutDuration: 10 * time.Second,
 	}
 
 	suite.migratorMock.On("Migrate", args).Return(suite.expectedErr).Once()
@@ -253,18 +326,63 @@ func (suite *CommanderTestSuite) Test_Down_ReturnsError_InCaseOfMissingArgumentN
 	suite.EqualError(err, "please specify <n>")
 }
 
-func (suite *CommanderTestSuite) Test_Down_ReturnsNil_InCaseOfSuccess() {
+func (suite *CommanderTestSuite) Test_Down_ReturnsNil_InCaseOfSuccessAndTimeoutDuration() {
 	// Arrange
 	suite.flagSet.String("path", "", "")
 	suite.flagSet.String("url", "", "")
-	suite.Require().NoError(suite.flagSet.Parse([]string{"--path", "testdata", "--url", "connectionurl", "123"}))
+	suite.flagSet.String("timeout-duration", "", "")
+	suite.flagSet.Duration("db-conn-timeout-duration", 10*time.Second, "")
+	suite.Require().NoError(
+		suite.flagSet.Parse([]string{
+			"--path", "testdata",
+			"--url", "connectionurl",
+			"--db-conn-timeout-duration", "10s",
+			"--timeout-duration", "10s",
+			"123",
+		}),
+	)
 
 	args := migrator.Args{
-		Path:            "testdata",
-		URL:             "connectionurl",
-		Direction:       direction.Down,
-		Steps:           123,
-		TimeoutDuration: 10 * time.Second,
+		Path:                        "testdata",
+		URL:                         "connectionurl",
+		Direction:                   direction.Down,
+		Steps:                       123,
+		TimeoutDuration:             10 * time.Second,
+		DBConnectionTimeoutDuration: 10 * time.Second,
+	}
+
+	suite.migratorMock.On("Migrate", args).Return(nil).Once()
+
+	// Act
+	err := suite.commander.Down(suite.ctx)
+
+	// Assert
+	suite.NoError(err)
+}
+
+func (suite *CommanderTestSuite) Test_Down_ReturnsNil_InCaseOfSuccessAndTimeout() {
+	// Arrange
+	suite.flagSet.String("path", "", "")
+	suite.flagSet.String("url", "", "")
+	suite.flagSet.String("timeout", "", "")
+	suite.flagSet.Duration("db-conn-timeout-duration", 10*time.Second, "")
+	suite.Require().NoError(
+		suite.flagSet.Parse([]string{
+			"--path", "testdata",
+			"--url", "connectionurl",
+			"--db-conn-timeout-duration", "10s",
+			"--timeout", "10",
+			"123",
+		}),
+	)
+
+	args := migrator.Args{
+		Path:                        "testdata",
+		URL:                         "connectionurl",
+		Direction:                   direction.Down,
+		Steps:                       123,
+		TimeoutDuration:             10 * time.Second,
+		DBConnectionTimeoutDuration: 10 * time.Second,
 	}
 
 	suite.migratorMock.On("Migrate", args).Return(nil).Once()

--- a/commander/commander_test.go
+++ b/commander/commander_test.go
@@ -3,10 +3,12 @@ package commander
 import (
 	"flag"
 	"testing"
+	"time"
 
 	"github.com/juju/errors"
 	"github.com/stretchr/testify/suite"
 	"github.com/urfave/cli"
+	"github.com/wallester/migrate/direction"
 	"github.com/wallester/migrate/file"
 	"github.com/wallester/migrate/migrator"
 )
@@ -68,7 +70,7 @@ func (suite *CommanderTestSuite) Test_Create_ReturnsError_InCaseOfMigratorError(
 	suite.Require().NoError(suite.flagSet.Parse([]string{"--path", "testdata", "create_table_users"}))
 
 	pair := &file.Pair{}
-	suite.migratorMock.On("Create", "create_table_users", "testdata").Return(pair, suite.expectedErr).Once()
+	suite.migratorMock.On("Create", "create_table_users", "testdata", false).Return(pair, suite.expectedErr).Once()
 
 	// Act
 	err := suite.commander.Create(suite.ctx)
@@ -83,7 +85,7 @@ func (suite *CommanderTestSuite) Test_Create_ReturnsNil_InCaseOfSuccess() {
 	suite.Require().NoError(suite.flagSet.Parse([]string{"--path", "testdata", "create_table_users"}))
 
 	pair := &file.Pair{}
-	suite.migratorMock.On("Create", "create_table_users", "testdata").Return(pair, nil).Once()
+	suite.migratorMock.On("Create", "create_table_users", "testdata", false).Return(pair, nil).Once()
 
 	// Act
 	err := suite.commander.Create(suite.ctx)
@@ -120,11 +122,11 @@ func (suite *CommanderTestSuite) Test_Up_ReturnsError_InCaseOfMigratorError() {
 	suite.Require().NoError(suite.flagSet.Parse([]string{"--path", "testdata", "--url", "connectionurl", "--timeout", "10"}))
 
 	args := migrator.Args{
-		Path:           "testdata",
-		URL:            "connectionurl",
-		Up:             true,
-		Steps:          0,
-		TimeoutSeconds: 10,
+		Path:            "testdata",
+		URL:             "connectionurl",
+		Direction:       direction.Up,
+		Steps:           0,
+		TimeoutDuration: 10 * time.Second,
 	}
 
 	suite.migratorMock.On("Migrate", args).Return(suite.expectedErr).Once()
@@ -156,11 +158,11 @@ func (suite *CommanderTestSuite) Test_Up_ReturnsNil_InCaseOfSuccess() {
 	suite.Require().NoError(suite.flagSet.Parse([]string{"--path", "testdata", "--url", "connectionurl"}))
 
 	args := migrator.Args{
-		Path:           "testdata",
-		URL:            "connectionurl",
-		Up:             true,
-		Steps:          0,
-		TimeoutSeconds: 1,
+		Path:            "testdata",
+		URL:             "connectionurl",
+		Direction:       direction.Up,
+		Steps:           0,
+		TimeoutDuration: 10 * time.Second,
 	}
 
 	suite.migratorMock.On("Migrate", args).Return(nil).Once()
@@ -179,11 +181,11 @@ func (suite *CommanderTestSuite) Test_Up_ReturnsNil_InCaseOfArgumentN() {
 	suite.Require().NoError(suite.flagSet.Parse([]string{"--path", "testdata", "--url", "connectionurl", "10"}))
 
 	args := migrator.Args{
-		Path:           "testdata",
-		URL:            "connectionurl",
-		Up:             true,
-		Steps:          10,
-		TimeoutSeconds: 1,
+		Path:            "testdata",
+		URL:             "connectionurl",
+		Direction:       direction.Up,
+		Steps:           10,
+		TimeoutDuration: 10 * time.Second,
 	}
 
 	suite.migratorMock.On("Migrate", args).Return(nil).Once()
@@ -222,11 +224,11 @@ func (suite *CommanderTestSuite) Test_Down_ReturnsError_InCaseOfMigratorError() 
 	suite.Require().NoError(suite.flagSet.Parse([]string{"--path", "testdata", "--url", "connectionurl", "123"}))
 
 	args := migrator.Args{
-		Path:           "testdata",
-		URL:            "connectionurl",
-		Up:             false,
-		Steps:          123,
-		TimeoutSeconds: 1,
+		Path:            "testdata",
+		URL:             "connectionurl",
+		Direction:       direction.Down,
+		Steps:           123,
+		TimeoutDuration: 10 * time.Second,
 	}
 
 	suite.migratorMock.On("Migrate", args).Return(suite.expectedErr).Once()
@@ -258,11 +260,11 @@ func (suite *CommanderTestSuite) Test_Down_ReturnsNil_InCaseOfSuccess() {
 	suite.Require().NoError(suite.flagSet.Parse([]string{"--path", "testdata", "--url", "connectionurl", "123"}))
 
 	args := migrator.Args{
-		Path:           "testdata",
-		URL:            "connectionurl",
-		Up:             false,
-		Steps:          123,
-		TimeoutSeconds: 1,
+		Path:            "testdata",
+		URL:             "connectionurl",
+		Direction:       direction.Down,
+		Steps:           123,
+		TimeoutDuration: 10 * time.Second,
 	}
 
 	suite.migratorMock.On("Migrate", args).Return(nil).Once()

--- a/direction/direction.go
+++ b/direction/direction.go
@@ -1,6 +1,30 @@
 package direction
 
-const (
-	Up   = true
-	Down = false
+import (
+	"github.com/mgutz/ansi"
 )
+
+// Direction is a boolean value that represents whether the database must be upgraded (Up) or downgraded (Down).
+type Direction bool
+
+const (
+	Up   Direction = true
+	Down Direction = false
+)
+
+// ToString returns the string representation of the direction.
+func (d Direction) ToString() string {
+	if d {
+		return "up"
+	}
+
+	return "down"
+}
+
+func (d Direction) ToANSIColoredPrefix() string {
+	if d {
+		return ansi.Green + ">" + ansi.Reset
+	}
+
+	return ansi.Red + ">" + ansi.Reset
+}

--- a/driver/driver.go
+++ b/driver/driver.go
@@ -3,15 +3,16 @@ package driver
 import (
 	"context"
 
+	"github.com/wallester/migrate/direction"
 	"github.com/wallester/migrate/file"
 	"github.com/wallester/migrate/version"
 )
 
-// Driver represents database driver
+// Driver represents database driver interface.
 type IDriver interface {
-	Open(url string) error
+	Open(ctx context.Context, url string) error
 	CreateMigrationsTable(ctx context.Context) error
 	SelectAllMigrations(ctx context.Context) (version.Versions, error)
-	Migrate(ctx context.Context, f file.File, up bool) error
+	Migrate(ctx context.Context, f file.File, d direction.Direction) error
 	Close() error
 }

--- a/driver/mock.go
+++ b/driver/mock.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/stretchr/testify/mock"
+	"github.com/wallester/migrate/direction"
 	"github.com/wallester/migrate/file"
 	"github.com/wallester/migrate/version"
 )
@@ -16,8 +17,8 @@ type Mock struct {
 var _ IDriver = (*Mock)(nil)
 
 // Open is a mock method
-func (m *Mock) Open(url string) error {
-	args := m.Called(url)
+func (m *Mock) Open(ctx context.Context, url string) error {
+	args := m.Called(ctx, url)
 	return args.Error(0)
 }
 
@@ -37,8 +38,8 @@ func (m *Mock) SelectAllMigrations(ctx context.Context) (version.Versions, error
 	return nil, args.Error(1)
 }
 
-func (m *Mock) Migrate(ctx context.Context, f file.File, up bool) error {
-	args := m.Called(ctx, f, up)
+func (m *Mock) Migrate(ctx context.Context, f file.File, d direction.Direction) error {
+	args := m.Called(ctx, f, d)
 	return args.Error(0)
 }
 

--- a/file/file.go
+++ b/file/file.go
@@ -61,8 +61,8 @@ func FindByVersion(version int64, files []File) *File {
 }
 
 // ListFiles lists migration files on a given path
-func ListFiles(path string, up bool) ([]File, error) {
-	files, err := filepath.Glob(filepath.Join(path, "*_*."+fileSuffix[up]+".sql"))
+func ListFiles(path string, d direction.Direction) ([]File, error) {
+	files, err := filepath.Glob(filepath.Join(path, "*_*."+d.ToString()+".sql"))
 	if err != nil {
 		return nil, errors.Annotate(err, "getting migration files failed")
 	}
@@ -88,7 +88,7 @@ func ListFiles(path string, up bool) ([]File, error) {
 		})
 	}
 
-	if up {
+	if d {
 		sort.Sort(ByBase(migrations))
 	} else {
 		sort.Sort(sort.Reverse(ByBase(migrations)))
@@ -107,9 +107,4 @@ func version(base string) (*int64, error) {
 	}
 
 	return &version, nil
-}
-
-var fileSuffix = map[bool]string{
-	direction.Up:   "up",
-	direction.Down: "down",
 }

--- a/flag/flag.go
+++ b/flag/flag.go
@@ -10,10 +10,18 @@ const (
 	URL = "url"
 	// Path represents migrations path.
 	Path = "path"
-	// Timeout represents execution timeout in seconds.
+	// Timeout represents execution timeout in seconds. Default value: 1s.
+	// Deprecated: use --timeout-duration instead.
 	Timeout = "timeout"
+	// TimeoutDuration represents execution timeout in duration.
+	// TimeoutDuration will override timeout setting. Default value: 1s.
+	TimeoutDuration = "timeout-duration"
+	// DBConnectionTimeoutDuration represents database connection timeout in duration. Default value: 1s.
+	DBConnectionTimeoutDuration = "db-conn-timeout-duration"
 	// NoVerify skips verification of already migrated older migrations.
 	NoVerify = "no-verify"
+	// Verbose enables verbose output.
+	Verbose = "verbose"
 )
 
 var Flags = map[string]cli.Flag{
@@ -27,6 +35,7 @@ var Flags = map[string]cli.Flag{
 		Usage:  "migrations folder, defaults to current working directory",
 		EnvVar: "MIGRATE_PATH",
 	},
+	// Deprecated, use TimeoutDuration instead.
 	Timeout: cli.StringFlag{
 		Name:   Timeout,
 		Usage:  "execution timeout in seconds, defaults to 1 second",
@@ -36,6 +45,21 @@ var Flags = map[string]cli.Flag{
 		Name:   NoVerify,
 		Usage:  "skip verification of already migrated older migrations",
 		EnvVar: "MIGRATE_NO_VERIFY",
+	},
+	Verbose: cli.BoolFlag{
+		Name:   Verbose,
+		Usage:  "enable verbose output",
+		EnvVar: "MIGRATE_VERBOSE",
+	},
+	TimeoutDuration: cli.DurationFlag{
+		Name:   TimeoutDuration,
+		Usage:  "execution timeout in duration, defaults to 1 second",
+		EnvVar: "MIGRATE_TIMEOUT_DURATION",
+	},
+	DBConnectionTimeoutDuration: cli.DurationFlag{
+		Name:   DBConnectionTimeoutDuration,
+		Usage:  "database connection timeout in duration, defaults to 1 second",
+		EnvVar: "MIGRATE_DB_CONN_TIMEOUT_DURATION",
 	},
 }
 

--- a/migrator/args.go
+++ b/migrator/args.go
@@ -13,8 +13,6 @@ type Args struct {
 	Path                        string
 	Steps                       int
 	TimeoutDuration             time.Duration
-	// Deprecated.  Use TimeoutDuration instead.
-	TimeoutSeconds int
-	URL            string
-	Verbose        bool
+	URL                         string
+	Verbose                     bool
 }

--- a/migrator/args.go
+++ b/migrator/args.go
@@ -1,10 +1,19 @@
 package migrator
 
+import (
+	"time"
+
+	"github.com/wallester/migrate/direction"
+)
+
 type Args struct {
-	Path           string
-	URL            string
-	Steps          int
-	TimeoutSeconds int
-	Up             bool
-	NoVerify       bool
+	DBConnectionTimeoutDuration time.Duration
+	Direction                   direction.Direction
+	NoVerify                    bool
+	Path                        string
+	Steps                       int
+	TimeoutDuration             time.Duration
+	TimeoutSeconds              int
+	URL                         string
+	Verbose                     bool
 }

--- a/migrator/args.go
+++ b/migrator/args.go
@@ -13,7 +13,8 @@ type Args struct {
 	Path                        string
 	Steps                       int
 	TimeoutDuration             time.Duration
-	TimeoutSeconds              int
-	URL                         string
-	Verbose                     bool
+	// Deprecated.  Use TimeoutDuration instead.
+	TimeoutSeconds int
+	URL            string
+	Verbose        bool
 }

--- a/migrator/migrator.go
+++ b/migrator/migrator.go
@@ -171,21 +171,21 @@ func (m *Migrator) applyMigrations(files []file.File, args Args) ([]file.File, e
 
 func (m *Migrator) chooseMigrations(files []file.File, alreadyMigrated version.Versions, args Args) ([]file.File, error) {
 	maxMigratedVersion := alreadyMigrated.Max()
-	boolDirection := bool(args.Direction)
+	up := bool(args.Direction)
 
 	needsMigration := make([]file.File, 0, len(files))
 	for _, f := range files {
 		_, isMigrated := alreadyMigrated[f.Version]
 
-		if boolDirection && isMigrated {
+		if up && isMigrated {
 			continue
 		}
 
-		if !boolDirection && !isMigrated {
+		if !up && !isMigrated {
 			continue
 		}
 
-		if boolDirection && maxMigratedVersion > f.Version && !args.NoVerify {
+		if up && maxMigratedVersion > f.Version && !args.NoVerify {
 			return nil, fmt.Errorf("cannot migrate up %s, because it's older than already migrated version %d", f.Base, maxMigratedVersion)
 		}
 
@@ -193,7 +193,7 @@ func (m *Migrator) chooseMigrations(files []file.File, alreadyMigrated version.V
 	}
 
 	totalFilesCount := len(needsMigration)
-	if totalFilesCount != 0 && args.Verbose {
+	if totalFilesCount > 0 && args.Verbose {
 		m.output.Println(fmt.Sprintf("%sTotal files to be migrated:%s %d", ansi.Yellow, ansi.Reset, totalFilesCount))
 	}
 

--- a/migrator/migrator.go
+++ b/migrator/migrator.go
@@ -109,12 +109,7 @@ func (m *Migrator) Create(name, path string, verbose bool) (*file.Pair, error) {
 // private
 
 func (m *Migrator) applyMigrations(files []file.File, args Args) ([]file.File, error) {
-	timeoutDuration := time.Duration(args.TimeoutSeconds * 1000)
-	if timeoutDuration == 0 {
-		timeoutDuration = args.TimeoutDuration
-	}
-
-	ctx, cancel := context.WithTimeout(context.Background(), timeoutDuration)
+	ctx, cancel := context.WithTimeout(context.Background(), args.TimeoutDuration)
 	defer cancel()
 
 	if err := m.db.CreateMigrationsTable(ctx); err != nil {

--- a/migrator/migrator.go
+++ b/migrator/migrator.go
@@ -148,6 +148,7 @@ func (m *Migrator) applyMigrations(files []file.File, args Args) ([]file.File, e
 				),
 			)
 		}
+		
 		if err := m.db.Migrate(ctx, f, args.Direction); err != nil {
 			return nil, errors.Annotatef(err, "applying migration failed: %s", f.Base)
 		}

--- a/migrator/migrator_test.go
+++ b/migrator/migrator_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/juju/errors"
 	"github.com/stretchr/testify/mock"
@@ -64,11 +65,11 @@ func (suite *MigratorTestSuite) Test_Migrate_ReturnsNil_InCaseOfNoUpMigrationsTo
 	suite.driverMock.On("Close").Return(nil).Once()
 
 	args := Args{
-		Path:           filepath.Join("..", "testdata"),
-		URL:            "connectionurl",
-		Up:             true,
-		Steps:          0,
-		TimeoutSeconds: 1,
+		Path:            filepath.Join("..", "testdata"),
+		URL:             "connectionurl",
+		Direction:       direction.Up,
+		Steps:           0,
+		TimeoutDuration: 10 * time.Second,
 	}
 
 	// Act
@@ -84,11 +85,11 @@ func (suite *MigratorTestSuite) Test_Migrate_ReturnsError_InCaseOfDriverOpenErro
 	suite.driverMock.On("Open", "connectionurl").Return(suite.expectedErr).Once()
 
 	args := Args{
-		Path:           filepath.Join("..", "testdata"),
-		URL:            "connectionurl",
-		Up:             true,
-		Steps:          0,
-		TimeoutSeconds: 1,
+		Path:            filepath.Join("..", "testdata"),
+		URL:             "connectionurl",
+		Direction:       direction.Up,
+		Steps:           0,
+		TimeoutDuration: 10 * time.Second,
 	}
 
 	// Act
@@ -106,11 +107,11 @@ func (suite *MigratorTestSuite) Test_Migrate_ReturnsError_InCaseOfDriverCreateMi
 	suite.driverMock.On("Close").Return(nil).Once()
 
 	args := Args{
-		Path:           filepath.Join("..", "testdata"),
-		URL:            "connectionurl",
-		Up:             true,
-		Steps:          0,
-		TimeoutSeconds: 1,
+		Path:            filepath.Join("..", "testdata"),
+		URL:             "connectionurl",
+		Direction:       direction.Up,
+		Steps:           0,
+		TimeoutDuration: 10 * time.Second,
 	}
 
 	// Act
@@ -129,11 +130,11 @@ func (suite *MigratorTestSuite) Test_Migrate_ReturnsErr_InCaseOfDriverSelectMigr
 	suite.driverMock.On("Close").Return(nil).Once()
 
 	args := Args{
-		Path:           filepath.Join("..", "testdata"),
-		URL:            "connectionurl",
-		Up:             true,
-		Steps:          0,
-		TimeoutSeconds: 1,
+		Path:            filepath.Join("..", "testdata"),
+		URL:             "connectionurl",
+		Direction:       direction.Up,
+		Steps:           0,
+		TimeoutDuration: 10 * time.Second,
 	}
 
 	// Act
@@ -169,11 +170,11 @@ func (suite *MigratorTestSuite) Test_Migrate_ReturnsError_InCaseOfDriverApplyMig
 	suite.driverMock.On("Close").Return(nil).Once()
 
 	args := Args{
-		Path:           filepath.Join("..", "testdata"),
-		URL:            "connectionurl",
-		Up:             true,
-		Steps:          0,
-		TimeoutSeconds: 1,
+		Path:            filepath.Join("..", "testdata"),
+		URL:             "connectionurl",
+		Direction:       direction.Up,
+		Steps:           0,
+		TimeoutDuration: 10 * time.Second,
 	}
 
 	// Act
@@ -208,11 +209,11 @@ func (suite *MigratorTestSuite) Test_Migrate_ReturnsNil_InCaseOfUpMigrationsToRu
 	suite.driverMock.On("Close").Return(nil).Once()
 
 	args := Args{
-		Path:           filepath.Join("..", "testdata"),
-		URL:            "connectionurl",
-		Up:             true,
-		Steps:          0,
-		TimeoutSeconds: 1,
+		Path:            filepath.Join("..", "testdata"),
+		URL:             "connectionurl",
+		Direction:       direction.Up,
+		Steps:           0,
+		TimeoutDuration: 10 * time.Second,
 	}
 
 	// Act
@@ -236,11 +237,11 @@ func (suite *MigratorTestSuite) Test_Migrate_ReturnsNil_InCaseOfNoDownMigrations
 	suite.driverMock.On("Close").Return(nil).Once()
 
 	args := Args{
-		Path:           filepath.Join("..", "testdata"),
-		URL:            "connectionurl",
-		Up:             false,
-		Steps:          0,
-		TimeoutSeconds: 1,
+		Path:            filepath.Join("..", "testdata"),
+		URL:             "connectionurl",
+		Direction:       direction.Down,
+		Steps:           0,
+		TimeoutDuration: 10 * time.Second,
 	}
 
 	// Act
@@ -275,11 +276,11 @@ func (suite *MigratorTestSuite) Test_Migrate_ReturnsNil_InCaseOfDownMigrationsTo
 	suite.driverMock.On("Close").Return(nil).Once()
 
 	args := Args{
-		Path:           filepath.Join("..", "testdata"),
-		URL:            "connectionurl",
-		Up:             false,
-		Steps:          0,
-		TimeoutSeconds: 1,
+		Path:            filepath.Join("..", "testdata"),
+		URL:             "connectionurl",
+		Direction:       direction.Down,
+		Steps:           0,
+		TimeoutDuration: 10 * time.Second,
 	}
 
 	// Act
@@ -293,10 +294,13 @@ func (suite *MigratorTestSuite) Test_Migrate_ReturnsNil_InCaseOfDownMigrationsTo
 
 func (suite *MigratorTestSuite) Test_Create_ReturnsNil_InCaseOfSuccess() {
 	// Arrange
-	const path = "."
+	const (
+		path    = "."
+		verbose = true
+	)
 
 	// Act
-	pair, err := suite.instance.Create("create_table_invoices", path)
+	pair, err := suite.instance.Create("create_table_invoices", path, verbose)
 
 	// Assert
 	suite.NoError(err)
@@ -335,11 +339,11 @@ func (suite *MigratorTestSuite) Test_Migrate_ReturnsNil_InCaseOfOneUpMigrationTo
 	suite.driverMock.On("Close").Return(nil).Once()
 
 	args := Args{
-		Path:           filepath.Join("..", "testdata"),
-		URL:            "connectionurl",
-		Up:             true,
-		Steps:          1,
-		TimeoutSeconds: 1,
+		Path:            filepath.Join("..", "testdata"),
+		URL:             "connectionurl",
+		Direction:       direction.Up,
+		Steps:           1,
+		TimeoutDuration: 10 * time.Second,
 	}
 
 	// Act
@@ -375,11 +379,11 @@ func (suite *MigratorTestSuite) Test_Migrate_ReturnsNil_InCaseOfOneDownMigration
 	suite.driverMock.On("Close").Return(nil).Once()
 
 	args := Args{
-		Path:           filepath.Join("..", "testdata"),
-		URL:            "connectionurl",
-		Up:             false,
-		Steps:          1,
-		TimeoutSeconds: 1,
+		Path:            filepath.Join("..", "testdata"),
+		URL:             "connectionurl",
+		Direction:       direction.Down,
+		Steps:           1,
+		TimeoutDuration: 10 * time.Second,
 	}
 
 	// Act
@@ -408,11 +412,11 @@ func (suite *MigratorTestSuite) Test_Migrate_ReturnsError_InCaseOfUpMigrationOld
 	suite.driverMock.On("Close").Return(nil).Once()
 
 	args := Args{
-		Path:           filepath.Join("..", "testdata"),
-		URL:            "connectionurl",
-		Up:             true,
-		Steps:          0,
-		TimeoutSeconds: 1,
+		Path:            filepath.Join("..", "testdata"),
+		URL:             "connectionurl",
+		Direction:       direction.Up,
+		Steps:           0,
+		TimeoutDuration: 10 * time.Second,
 	}
 
 	// Act
@@ -447,12 +451,12 @@ func (suite *MigratorTestSuite) Test_Migrate_ReturnsNoError_InCaseOfUpMigrationO
 	suite.driverMock.On("Close").Return(nil).Once()
 
 	args := Args{
-		Path:           filepath.Join("..", "testdata"),
-		URL:            "connectionurl",
-		Up:             true,
-		Steps:          0,
-		TimeoutSeconds: 1,
-		NoVerify:       true,
+		Path:            filepath.Join("..", "testdata"),
+		URL:             "connectionurl",
+		Direction:       direction.Up,
+		Steps:           0,
+		TimeoutDuration: 10 * time.Second,
+		NoVerify:        true,
 	}
 
 	// Act

--- a/migrator/migrator_test.go
+++ b/migrator/migrator_test.go
@@ -59,7 +59,7 @@ func (suite *MigratorTestSuite) Test_Migrate_ReturnsNil_InCaseOfNoUpMigrationsTo
 		1494538317: exists,
 		1494538407: exists,
 	}
-	suite.driverMock.On("Open", "connectionurl").Return(nil).Once()
+	suite.driverMock.On("Open", mock.AnythingOfType("*context.timerCtx"), "connectionurl").Return(nil).Once()
 	suite.driverMock.On("CreateMigrationsTable", mock.AnythingOfType("*context.timerCtx")).Return(nil).Once()
 	suite.driverMock.On("SelectAllMigrations", mock.AnythingOfType("*context.timerCtx")).Return(migrations, nil).Once()
 	suite.driverMock.On("Close").Return(nil).Once()
@@ -70,6 +70,7 @@ func (suite *MigratorTestSuite) Test_Migrate_ReturnsNil_InCaseOfNoUpMigrationsTo
 		Direction:       direction.Up,
 		Steps:           0,
 		TimeoutDuration: 10 * time.Second,
+		Verbose:         true,
 	}
 
 	// Act
@@ -82,7 +83,7 @@ func (suite *MigratorTestSuite) Test_Migrate_ReturnsNil_InCaseOfNoUpMigrationsTo
 
 func (suite *MigratorTestSuite) Test_Migrate_ReturnsError_InCaseOfDriverOpenError() {
 	// Arrange
-	suite.driverMock.On("Open", "connectionurl").Return(suite.expectedErr).Once()
+	suite.driverMock.On("Open", mock.AnythingOfType("*context.timerCtx"), "connectionurl").Return(suite.expectedErr).Once()
 
 	args := Args{
 		Path:            filepath.Join("..", "testdata"),
@@ -102,7 +103,7 @@ func (suite *MigratorTestSuite) Test_Migrate_ReturnsError_InCaseOfDriverOpenErro
 
 func (suite *MigratorTestSuite) Test_Migrate_ReturnsError_InCaseOfDriverCreateMigrationsTableError() {
 	// Arrange
-	suite.driverMock.On("Open", "connectionurl").Return(nil).Once()
+	suite.driverMock.On("Open", mock.AnythingOfType("*context.timerCtx"), "connectionurl").Return(nil).Once()
 	suite.driverMock.On("CreateMigrationsTable", mock.AnythingOfType("*context.timerCtx")).Return(suite.expectedErr).Once()
 	suite.driverMock.On("Close").Return(nil).Once()
 
@@ -124,7 +125,7 @@ func (suite *MigratorTestSuite) Test_Migrate_ReturnsError_InCaseOfDriverCreateMi
 
 func (suite *MigratorTestSuite) Test_Migrate_ReturnsErr_InCaseOfDriverSelectMigrationsError() {
 	// Arrange
-	suite.driverMock.On("Open", "connectionurl").Return(nil).Once()
+	suite.driverMock.On("Open", mock.AnythingOfType("*context.timerCtx"), "connectionurl").Return(nil).Once()
 	suite.driverMock.On("CreateMigrationsTable", mock.AnythingOfType("*context.timerCtx")).Return(nil).Once()
 	suite.driverMock.On("SelectAllMigrations", mock.AnythingOfType("*context.timerCtx")).Return(nil, suite.expectedErr).Once()
 	suite.driverMock.On("Close").Return(nil).Once()
@@ -163,10 +164,10 @@ func (suite *MigratorTestSuite) Test_Migrate_ReturnsError_InCaseOfDriverApplyMig
 		*file.FindByVersion(1494538407, files),
 	}
 
-	suite.driverMock.On("Open", "connectionurl").Return(nil).Once()
+	suite.driverMock.On("Open", mock.AnythingOfType("*context.timerCtx"), "connectionurl").Return(nil).Once()
 	suite.driverMock.On("CreateMigrationsTable", mock.AnythingOfType("*context.timerCtx")).Return(nil).Once()
 	suite.driverMock.On("SelectAllMigrations", mock.AnythingOfType("*context.timerCtx")).Return(migrations, nil).Once()
-	suite.driverMock.On("Migrate", mock.AnythingOfType("*context.timerCtx"), needsMigration[0], true).Return(suite.expectedErr).Once()
+	suite.driverMock.On("Migrate", mock.AnythingOfType("*context.timerCtx"), needsMigration[0], direction.Up).Return(suite.expectedErr).Once()
 	suite.driverMock.On("Close").Return(nil).Once()
 
 	args := Args{
@@ -202,10 +203,10 @@ func (suite *MigratorTestSuite) Test_Migrate_ReturnsNil_InCaseOfUpMigrationsToRu
 		*file.FindByVersion(1494538407, files),
 	}
 
-	suite.driverMock.On("Open", "connectionurl").Return(nil).Once()
+	suite.driverMock.On("Open", mock.AnythingOfType("*context.timerCtx"), "connectionurl").Return(nil).Once()
 	suite.driverMock.On("CreateMigrationsTable", mock.AnythingOfType("*context.timerCtx")).Return(nil).Once()
 	suite.driverMock.On("SelectAllMigrations", mock.AnythingOfType("*context.timerCtx")).Return(migrations, nil).Once()
-	suite.driverMock.On("Migrate", mock.AnythingOfType("*context.timerCtx"), needsMigration[0], true).Return(nil).Once()
+	suite.driverMock.On("Migrate", mock.AnythingOfType("*context.timerCtx"), needsMigration[0], direction.Up).Return(nil).Once()
 	suite.driverMock.On("Close").Return(nil).Once()
 
 	args := Args{
@@ -214,6 +215,7 @@ func (suite *MigratorTestSuite) Test_Migrate_ReturnsNil_InCaseOfUpMigrationsToRu
 		Direction:       direction.Up,
 		Steps:           0,
 		TimeoutDuration: 10 * time.Second,
+		Verbose:         true,
 	}
 
 	// Act
@@ -231,7 +233,7 @@ func (suite *MigratorTestSuite) Test_Migrate_ReturnsNil_InCaseOfNoDownMigrations
 	// We'll mark all of them as never been migrated, meaning
 	// none of them need to be migrated down.
 	migrations := make(version.Versions)
-	suite.driverMock.On("Open", "connectionurl").Return(nil).Once()
+	suite.driverMock.On("Open", mock.AnythingOfType("*context.timerCtx"), "connectionurl").Return(nil).Once()
 	suite.driverMock.On("CreateMigrationsTable", mock.AnythingOfType("*context.timerCtx")).Return(nil).Once()
 	suite.driverMock.On("SelectAllMigrations", mock.AnythingOfType("*context.timerCtx")).Return(migrations, nil).Once()
 	suite.driverMock.On("Close").Return(nil).Once()
@@ -242,6 +244,7 @@ func (suite *MigratorTestSuite) Test_Migrate_ReturnsNil_InCaseOfNoDownMigrations
 		Direction:       direction.Down,
 		Steps:           0,
 		TimeoutDuration: 10 * time.Second,
+		Verbose:         true,
 	}
 
 	// Act
@@ -269,10 +272,10 @@ func (suite *MigratorTestSuite) Test_Migrate_ReturnsNil_InCaseOfDownMigrationsTo
 		*file.FindByVersion(1494538407, files),
 	}
 
-	suite.driverMock.On("Open", "connectionurl").Return(nil).Once()
+	suite.driverMock.On("Open", mock.AnythingOfType("*context.timerCtx"), "connectionurl").Return(nil).Once()
 	suite.driverMock.On("CreateMigrationsTable", mock.AnythingOfType("*context.timerCtx")).Return(nil).Once()
 	suite.driverMock.On("SelectAllMigrations", mock.AnythingOfType("*context.timerCtx")).Return(migrations, nil).Once()
-	suite.driverMock.On("Migrate", mock.AnythingOfType("*context.timerCtx"), needsMigration[0], false).Return(nil).Once()
+	suite.driverMock.On("Migrate", mock.AnythingOfType("*context.timerCtx"), needsMigration[0], direction.Down).Return(nil).Once()
 	suite.driverMock.On("Close").Return(nil).Once()
 
 	args := Args{
@@ -281,6 +284,7 @@ func (suite *MigratorTestSuite) Test_Migrate_ReturnsNil_InCaseOfDownMigrationsTo
 		Direction:       direction.Down,
 		Steps:           0,
 		TimeoutDuration: 10 * time.Second,
+		Verbose:         true,
 	}
 
 	// Act
@@ -313,13 +317,6 @@ func (suite *MigratorTestSuite) Test_Create_ReturnsNil_InCaseOfSuccess() {
 	suite.True(suite.output.Contains(pair.Down.Base))
 }
 
-func remove(filename string) {
-	if err := os.Remove(filename); err != nil {
-		//nolint:forbidigo
-		fmt.Println("removing file failed", err)
-	}
-}
-
 func (suite *MigratorTestSuite) Test_Migrate_ReturnsNil_InCaseOfOneUpMigrationToRun() {
 	// Arrange
 	// The following versions are from ../testdata.
@@ -332,10 +329,10 @@ func (suite *MigratorTestSuite) Test_Migrate_ReturnsNil_InCaseOfOneUpMigrationTo
 		*file.FindByVersion(1494538273, files),
 	}
 
-	suite.driverMock.On("Open", "connectionurl").Return(nil).Once()
+	suite.driverMock.On("Open", mock.AnythingOfType("*context.timerCtx"), "connectionurl").Return(nil).Once()
 	suite.driverMock.On("CreateMigrationsTable", mock.AnythingOfType("*context.timerCtx")).Return(nil).Once()
 	suite.driverMock.On("SelectAllMigrations", mock.AnythingOfType("*context.timerCtx")).Return(migrations, nil).Once()
-	suite.driverMock.On("Migrate", mock.AnythingOfType("*context.timerCtx"), needsMigration[0], true).Return(nil).Once()
+	suite.driverMock.On("Migrate", mock.AnythingOfType("*context.timerCtx"), needsMigration[0], direction.Up).Return(nil).Once()
 	suite.driverMock.On("Close").Return(nil).Once()
 
 	args := Args{
@@ -344,6 +341,7 @@ func (suite *MigratorTestSuite) Test_Migrate_ReturnsNil_InCaseOfOneUpMigrationTo
 		Direction:       direction.Up,
 		Steps:           1,
 		TimeoutDuration: 10 * time.Second,
+		Verbose:         true,
 	}
 
 	// Act
@@ -372,10 +370,10 @@ func (suite *MigratorTestSuite) Test_Migrate_ReturnsNil_InCaseOfOneDownMigration
 		*file.FindByVersion(1494538407, files),
 	}
 
-	suite.driverMock.On("Open", "connectionurl").Return(nil).Once()
+	suite.driverMock.On("Open", mock.AnythingOfType("*context.timerCtx"), "connectionurl").Return(nil).Once()
 	suite.driverMock.On("CreateMigrationsTable", mock.AnythingOfType("*context.timerCtx")).Return(nil).Once()
 	suite.driverMock.On("SelectAllMigrations", mock.AnythingOfType("*context.timerCtx")).Return(migrations, nil).Once()
-	suite.driverMock.On("Migrate", mock.AnythingOfType("*context.timerCtx"), needsMigration[0], false).Return(nil).Once()
+	suite.driverMock.On("Migrate", mock.AnythingOfType("*context.timerCtx"), needsMigration[0], direction.Down).Return(nil).Once()
 	suite.driverMock.On("Close").Return(nil).Once()
 
 	args := Args{
@@ -384,6 +382,7 @@ func (suite *MigratorTestSuite) Test_Migrate_ReturnsNil_InCaseOfOneDownMigration
 		Direction:       direction.Down,
 		Steps:           1,
 		TimeoutDuration: 10 * time.Second,
+		Verbose:         true,
 	}
 
 	// Act
@@ -406,7 +405,7 @@ func (suite *MigratorTestSuite) Test_Migrate_ReturnsError_InCaseOfUpMigrationOld
 		1494538407: exists,
 	}
 
-	suite.driverMock.On("Open", "connectionurl").Return(nil).Once()
+	suite.driverMock.On("Open", mock.AnythingOfType("*context.timerCtx"), "connectionurl").Return(nil).Once()
 	suite.driverMock.On("CreateMigrationsTable", mock.AnythingOfType("*context.timerCtx")).Return(nil).Once()
 	suite.driverMock.On("SelectAllMigrations", mock.AnythingOfType("*context.timerCtx")).Return(migrations, nil).Once()
 	suite.driverMock.On("Close").Return(nil).Once()
@@ -444,10 +443,10 @@ func (suite *MigratorTestSuite) Test_Migrate_ReturnsNoError_InCaseOfUpMigrationO
 		*file.FindByVersion(1494538317, files),
 	}
 
-	suite.driverMock.On("Open", "connectionurl").Return(nil).Once()
+	suite.driverMock.On("Open", mock.AnythingOfType("*context.timerCtx"), "connectionurl").Return(nil).Once()
 	suite.driverMock.On("CreateMigrationsTable", mock.AnythingOfType("*context.timerCtx")).Return(nil).Once()
 	suite.driverMock.On("SelectAllMigrations", mock.AnythingOfType("*context.timerCtx")).Return(migrations, nil).Once()
-	suite.driverMock.On("Migrate", mock.AnythingOfType("*context.timerCtx"), needsMigration[0], true).Return(nil).Once()
+	suite.driverMock.On("Migrate", mock.AnythingOfType("*context.timerCtx"), needsMigration[0], direction.Up).Return(nil).Once()
 	suite.driverMock.On("Close").Return(nil).Once()
 
 	args := Args{
@@ -464,4 +463,49 @@ func (suite *MigratorTestSuite) Test_Migrate_ReturnsNoError_InCaseOfUpMigrationO
 
 	// Assert
 	suite.NoError(err)
+}
+
+func (suite *MigratorTestSuite) Test_Migrate_ReturnsNoVerboseOutput_InCaseOfVerboseFlagOff() {
+	// Arrange
+	// The following versions are from ../testdata.
+	migrations := make(version.Versions)
+
+	files, err := file.ListFiles(filepath.Join("..", "testdata"), direction.Up)
+	suite.Require().NoError(err)
+
+	needsMigration := []file.File{
+		*file.FindByVersion(1494538273, files),
+	}
+
+	suite.driverMock.On("Open", mock.AnythingOfType("*context.timerCtx"), "connectionurl").Return(nil).Once()
+	suite.driverMock.On("CreateMigrationsTable", mock.AnythingOfType("*context.timerCtx")).Return(nil).Once()
+	suite.driverMock.On("SelectAllMigrations", mock.AnythingOfType("*context.timerCtx")).Return(migrations, nil).Once()
+	suite.driverMock.On("Migrate", mock.AnythingOfType("*context.timerCtx"), needsMigration[0], direction.Up).Return(nil).Once()
+	suite.driverMock.On("Close").Return(nil).Once()
+
+	args := Args{
+		Path:            filepath.Join("..", "testdata"),
+		URL:             "connectionurl",
+		Direction:       direction.Up,
+		Steps:           1,
+		TimeoutDuration: 10 * time.Second,
+		Verbose:         false,
+	}
+
+	// Act
+	err = suite.instance.Migrate(args)
+
+	// Assert
+	suite.NoError(errors.Cause(err))
+	suite.True(suite.output.Contains("1494538273_create_table_users.up.sql"))
+	suite.False(suite.output.Contains("seconds"))
+}
+
+// private
+
+func remove(filename string) {
+	if err := os.Remove(filename); err != nil {
+		//nolint:forbidigo
+		fmt.Println("removing file failed", err)
+	}
 }

--- a/migrator/mock.go
+++ b/migrator/mock.go
@@ -19,8 +19,8 @@ func (m *Mock) Migrate(a Args) error {
 }
 
 // Create is a mock method
-func (m *Mock) Create(name string, path string) (*file.Pair, error) {
-	args := m.Called(name, path)
+func (m *Mock) Create(name, path string, verbose bool) (*file.Pair, error) {
+	args := m.Called(name, path, verbose)
 	if args.Get(0) != nil {
 		return args.Get(0).(*file.Pair), args.Error(1)
 	}


### PR DESCRIPTION
In scope of this PR, I have added new `timeout-duration` flag, which allows to set timeout for migrations in duration format (e.g 30s, 5m) and added new `verbose` flag which enables better logging about what is happening with migrations. Please see attached screenshots for examples.

Also includes some small code refactorings :)
`verbose` flag is `enabled`
<img width="654" alt="Screenshot 2023-07-28 at 00 00 37" src="https://github.com/wallester/migrate/assets/32199530/4319d37d-32d1-4647-be0f-01b545df41b4">

`verbose` flag is `disabled`
<img width="303" alt="Screenshot 2023-07-27 at 23 59 00" src="https://github.com/wallester/migrate/assets/32199530/9cd34a9d-f240-4cd3-a523-f3063b190abe">

Example command for both flags:
```
./migrate -url "postgres://user:password@localhost/db?sslmode=disable" -path ./migrations -timeout-duration 5m -verbose down 1
```

p.s suggestions welcome